### PR TITLE
Fix the footer to get the current year

### DIFF
--- a/layouts/partials/custom-footer.html
+++ b/layouts/partials/custom-footer.html
@@ -1,5 +1,5 @@
 <footer>
-  <div id="R-homelinks" class="default-animation homelinks"> 
+  <div id="R-homelinks" class="default-animation homelinks">
     <hr class="padding">
   </div>
   <div class="footer-content">
@@ -30,7 +30,7 @@
       <!-- Footer Bottom Text -->
       <div class="footer-section">
           <p class="sitename">IEEE Industrial Electronics Society</p>
-          <p>© Copyright 2024 IEEE - All rights reserved. A not-for-profit organization, IEEE is the world's largest technical professional organization dedicated to advancing technology for the benefit of humanity.</p>
+          <p>&copy; Copyright {{ now.Format "2006" }} IEEE - All rights reserved. A not-for-profit organization, IEEE is the world's largest technical professional organization dedicated to advancing technology for the benefit of humanity.</p>
       </div>
   </div>
 </footer>


### PR DESCRIPTION
Currently, 2024 is hardcoded, which leads to old dates on websites. This commit fixes the issue by using always the current year.